### PR TITLE
Fix side effects on import

### DIFF
--- a/TableComparer/muhasebe.py
+++ b/TableComparer/muhasebe.py
@@ -142,7 +142,9 @@ class FileComparer(QWidget):
         print(f"Farklı kayıtlar '{output_file}' dosyasına kaydedildi.")
         QApplication.quit()
 
-app = QApplication(sys.argv)
-window = FileComparer()
-window.show()
-sys.exit(app.exec_())
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = FileComparer()
+    window.show()
+    sys.exit(app.exec_())


### PR DESCRIPTION
## Summary
- avoid starting Qt when module is imported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469128ef5083289bb407745cebecd3